### PR TITLE
MULE-12903: Every exported Mule package must contain api (part2)

### DIFF
--- a/src/test/java/org/mule/extension/db/integration/AbstractQueryTimeoutTestCase.java
+++ b/src/test/java/org/mule/extension/db/integration/AbstractQueryTimeoutTestCase.java
@@ -14,7 +14,7 @@ import static org.hamcrest.core.Is.is;
 
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.core.api.Event;
-import org.mule.runtime.core.exception.MessagingException;
+import org.mule.runtime.core.api.exception.MessagingException;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/org/mule/extension/db/integration/insert/BulkInsertTestCase.java
+++ b/src/test/java/org/mule/extension/db/integration/insert/BulkInsertTestCase.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.rules.ExpectedException.none;
 import org.mule.extension.db.integration.AbstractDbIntegrationTestCase;
 import org.mule.runtime.api.message.Message;
-import org.mule.runtime.core.exception.MessagingException;
+import org.mule.runtime.core.api.exception.MessagingException;
 
 import java.sql.SQLException;
 import java.util.ArrayList;

--- a/src/test/java/org/mule/extension/db/integration/select/SelectExceptionTestCase.java
+++ b/src/test/java/org/mule/extension/db/integration/select/SelectExceptionTestCase.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import org.mule.extension.db.integration.AbstractDbIntegrationTestCase;
 import org.mule.extension.db.integration.model.DerbyTestDatabase;
-import org.mule.runtime.core.exception.MessagingException;
+import org.mule.runtime.core.api.exception.MessagingException;
 
 import java.util.List;
 

--- a/src/test/java/org/mule/extension/db/integration/transaction/AbstractTxDbIntegrationTestCase.java
+++ b/src/test/java/org/mule/extension/db/integration/transaction/AbstractTxDbIntegrationTestCase.java
@@ -15,7 +15,7 @@ import static org.mule.extension.db.integration.DbTestUtil.selectData;
 
 import org.mule.extension.db.integration.AbstractDbIntegrationTestCase;
 import org.mule.functional.junit4.FlowRunner;
-import org.mule.runtime.core.exception.MessagingException;
+import org.mule.runtime.core.api.exception.MessagingException;
 
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
MULE-10370: Remove custom-exception-strategy element

_ Moving classes from org.mule.runtime.core.extension to api/internal
_ Temporarily exporting org.mule.runtime.core.internal.extension (because MULE-12427)
_ Adding test:exception-strategy for tests to replace mule:custom-exception-strategy
_ Removing mule:custom-exception-strategy element