### PR TITLE
MULE-12327: ArtifactClassLoaderRunner - Application URLs are also

### DIFF
--- a/src/test/java/org/mule/extension/db/integration/AbstractDbIntegrationTestCase.java
+++ b/src/test/java/org/mule/extension/db/integration/AbstractDbIntegrationTestCase.java
@@ -28,7 +28,7 @@ import org.mule.extension.db.integration.model.Field;
 import org.mule.extension.db.integration.model.Record;
 import org.mule.extension.db.internal.domain.connection.DbConnection;
 import org.mule.extension.db.internal.domain.connection.DbConnectionProvider;
-import org.mule.functional.junit4.FlowRunner;
+import org.mule.functional.api.flow.FlowRunner;
 import org.mule.functional.junit4.MuleArtifactFunctionalTestCase;
 import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.metadata.api.builder.BaseTypeBuilder;

--- a/src/test/java/org/mule/extension/db/integration/transaction/AbstractTxDbIntegrationTestCase.java
+++ b/src/test/java/org/mule/extension/db/integration/transaction/AbstractTxDbIntegrationTestCase.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertThat;
 import static org.mule.extension.db.integration.DbTestUtil.selectData;
 
 import org.mule.extension.db.integration.AbstractDbIntegrationTestCase;
-import org.mule.functional.junit4.FlowRunner;
+import org.mule.functional.api.flow.FlowRunner;
 import org.mule.runtime.core.api.exception.MessagingException;
 
 import java.util.List;


### PR DESCRIPTION
including transitive dependencies from filter ones
* Cleanup test artifact dependencies so no unwanted transitive
dependencies end up in the APP classloader for tests
* Refactor flowRunner so that test artifact doesn't bring its transitive
dependencies