### PR TITLE
MULE-13545: Cleanup core API

### DIFF
--- a/src/main/java/org/mule/extension/db/internal/domain/connection/DataSourceFactory.java
+++ b/src/main/java/org/mule/extension/db/internal/domain/connection/DataSourceFactory.java
@@ -7,12 +7,12 @@
 
 package org.mule.extension.db.internal.domain.connection;
 
+import static java.util.concurrent.ConcurrentHashMap.newKeySet;
 import org.mule.extension.db.api.config.DbPoolingProfile;
 import org.mule.extension.db.internal.domain.xa.CompositeDataSourceDecorator;
 import org.mule.runtime.api.config.DatabasePoolingProfile;
 import org.mule.runtime.api.lifecycle.Disposable;
 import org.mule.runtime.api.tx.DataSourceDecorator;
-import org.mule.runtime.core.api.util.concurrent.ConcurrentHashSet;
 
 import com.mchange.v2.c3p0.DataSources;
 
@@ -37,8 +37,8 @@ public class DataSourceFactory implements Disposable {
   private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceFactory.class);
 
   private final String name;
-  private final Set<DataSource> pooledDataSources = new ConcurrentHashSet();
-  private final Set<Disposable> disposableDataSources = new ConcurrentHashSet();
+  private final Set<DataSource> pooledDataSources = newKeySet();
+  private final Set<Disposable> disposableDataSources = newKeySet();
   private final CompositeDataSourceDecorator dataSourceDecorator;
 
   public DataSourceFactory(String name, Collection<DataSourceDecorator> dataSourceDecorators) {

--- a/src/main/java/org/mule/extension/db/internal/domain/connection/DbConnectionProvider.java
+++ b/src/main/java/org/mule/extension/db/internal/domain/connection/DbConnectionProvider.java
@@ -15,7 +15,7 @@ import static org.mule.runtime.api.connection.ConnectionValidationResult.success
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.api.meta.ExpressionSupport.NOT_SUPPORTED;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
-import static org.mule.runtime.core.api.util.collection.Collectors.toImmutableList;
+import static org.mule.runtime.api.util.collection.Collectors.toImmutableList;
 import static org.mule.runtime.extension.api.annotation.param.display.Placement.ADVANCED_TAB;
 import static org.slf4j.LoggerFactory.getLogger;
 import org.mule.extension.db.api.config.DbPoolingProfile;

--- a/src/test/java/org/mule/extension/db/integration/AbstractDbIntegrationTestCase.java
+++ b/src/test/java/org/mule/extension/db/integration/AbstractDbIntegrationTestCase.java
@@ -22,7 +22,7 @@ import static org.mule.extension.db.integration.TestRecordUtil.assertRecords;
 import static org.mule.metadata.api.model.MetadataFormat.JAVA;
 import static org.mule.runtime.api.component.location.Location.builder;
 import static org.mule.runtime.api.metadata.MetadataKeyBuilder.newKey;
-import static org.mule.runtime.core.api.connection.ConnectionProviderUtils.unwrapProviderWrapper;
+import static org.mule.runtime.module.extension.api.util.ConnectionProviderUtils.unwrapProviderWrapper;
 import org.mule.extension.db.api.StatementResult;
 import org.mule.extension.db.integration.model.AbstractTestDatabase;
 import org.mule.extension.db.integration.model.Field;


### PR DESCRIPTION
_ Moving classes out of core's api package
_ When possible, classes where moved to internal
_ Moved to privileged when classes where required on compatibility
_ Moved to other module's API when needed on tests or it made sense
_ Deleted if not needed anymore
_ Some tests were ignored as they use an internal class and need refactoring