### PR TITLE
MULE-13132: Add support to access privileged API class from test case

### DIFF
--- a/src/test/java/org/mule/extension/db/integration/DbArtifactClassLoaderRunnerConfig.java
+++ b/src/test/java/org/mule/extension/db/integration/DbArtifactClassLoaderRunnerConfig.java
@@ -18,6 +18,6 @@ import org.mule.test.runner.ArtifactClassLoaderRunnerConfig;
  */
 @ArtifactClassLoaderRunnerConfig(
     exportPluginClasses = {DbConnectionProvider.class, StatementStreamingResultSetCloser.class},
-    sharedRuntimeLibs = {"org.apache.derby:derby", "org.mule.tests:mule-tests-unit"})
+    applicationSharedRuntimeLibs = {"org.apache.derby:derby"})
 public interface DbArtifactClassLoaderRunnerConfig {
 }


### PR DESCRIPTION
_ Adding a test-runner plugin to contain test code and access privileged APIs
_ Application's context is created using the application classloader
_ Test is executed using test runner classloader
_ Adding runner configuration attribute to set application libraries (not visible to plugins)
_ Adding runner configuration attribute to set exported libraries from the test runner
_ Extracting mule-test-model artifact form mule-test-unit to contain all the classes that are used from different plugins and needs to be shared from the application
_ Enabling defining mule modules with privileged exported packages but no privileges artifacts