### PR TITLE
MULE-17394: Oracle stored procedure call with ARRAY parameter takes 5…

### DIFF
--- a/src/main/java/org/mule/extension/db/internal/parser/SimpleQueryTemplateParser.java
+++ b/src/main/java/org/mule/extension/db/internal/parser/SimpleQueryTemplateParser.java
@@ -8,6 +8,7 @@
 package org.mule.extension.db.internal.parser;
 
 import static org.mule.runtime.core.api.util.StringUtils.isEmpty;
+
 import org.mule.extension.db.internal.domain.param.DefaultInputQueryParam;
 import org.mule.extension.db.internal.domain.param.QueryParam;
 import org.mule.extension.db.internal.domain.query.QueryTemplate;
@@ -106,9 +107,7 @@ public class SimpleQueryTemplateParser implements QueryTemplateParser {
       throw new QueryTemplateParsingException("SQL text cannot be empty");
     }
 
-    if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("Parsing SQL: " + sqlText);
-    }
+    LOGGER.debug("Parsing SQL: {}", sqlText);
 
     StringBuilder sqlToUse = new StringBuilder();
     List<QueryParam> parameterList = new ArrayList<>();

--- a/src/main/java/org/mule/extension/db/internal/resolver/param/StoredProcedureParamTypeResolver.java
+++ b/src/main/java/org/mule/extension/db/internal/resolver/param/StoredProcedureParamTypeResolver.java
@@ -9,6 +9,7 @@ package org.mule.extension.db.internal.resolver.param;
 import static java.lang.String.format;
 import static org.mule.extension.db.internal.domain.connection.oracle.OracleDbConnection.TABLE_TYPE_NAME;
 import static org.mule.extension.db.internal.util.StoredProcedureUtils.getStoredProcedureName;
+import static org.mule.extension.db.internal.util.StoredProcedureUtils.getStoreProcedureSchema;
 
 import org.mule.extension.db.api.param.ParameterType;
 import org.mule.extension.db.internal.domain.connection.DbConnection;
@@ -63,8 +64,14 @@ public class StoredProcedureParamTypeResolver implements ParamTypeResolver {
       storedProcedureName = storedProcedureName.toUpperCase();
     }
 
+    String storedProcedureSchema = getStoreProcedureSchema(queryTemplate.getSqlText()).orElse(null);
+    if (dbMetaData.storesUpperCaseIdentifiers() && storedProcedureSchema != null) {
+      storedProcedureSchema = storedProcedureSchema.toUpperCase();
+    }
+
     ResultSet procedureColumns =
-        dbMetaData.getProcedureColumns(connection.getJdbcConnection().getCatalog(), null, storedProcedureName, "%");
+        dbMetaData.getProcedureColumns(connection.getJdbcConnection().getCatalog(), storedProcedureSchema, storedProcedureName,
+                                       "%");
 
     try {
       Map<Integer, DbType> paramTypes = getStoredProcedureParamTypes(connection, storedProcedureName, procedureColumns);

--- a/src/main/java/org/mule/extension/db/internal/util/StoredProcedureUtils.java
+++ b/src/main/java/org/mule/extension/db/internal/util/StoredProcedureUtils.java
@@ -7,6 +7,7 @@
 package org.mule.extension.db.internal.util;
 
 import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.sql.SQLException;
 import java.util.Optional;
@@ -59,9 +60,10 @@ public class StoredProcedureUtils {
 
     String schemaText = matcher.group(2);
 
-    if (schemaText == null) {
+    if (isBlank(schemaText)) {
       return Optional.empty();
     } else {
+      // Remove the dot at the end of the text
       String schemaName = schemaText.substring(0, schemaText.length() - 1);
       return Optional.of(schemaName);
     }

--- a/src/main/java/org/mule/extension/db/internal/util/StoredProcedureUtils.java
+++ b/src/main/java/org/mule/extension/db/internal/util/StoredProcedureUtils.java
@@ -9,6 +9,7 @@ package org.mule.extension.db.internal.util;
 import static java.lang.String.format;
 
 import java.sql.SQLException;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -19,16 +20,51 @@ import java.util.regex.Pattern;
  */
 public class StoredProcedureUtils {
 
-  private final static Pattern storedProcedureMatcher = Pattern.compile("(?msi)(\\{\\s*)?call\\s+(\\w+\\.)?(\\w+)\\s*\\(.*");
+  private static final String STORED_PROCEDURE_REGEX = "(?msi)(\\{\\s*)?call\\s+(\\w+\\.)?(\\w+)\\s*\\(.*";
 
+  private final static Pattern storedProcedurePattern = Pattern.compile(STORED_PROCEDURE_REGEX);
+
+
+  /**
+   * Gets the name of the stored procedure of the given SQL Query.
+   *
+   * @param sqlText the SQL Query text
+   * @return the name of the stored procedure
+   * @throws SQLException if it is no possible to get name of the stored procedure from the given SQL Query or the
+   *         SQL Query syntax is not valid
+   */
   public static String getStoredProcedureName(String sqlText) throws SQLException {
-    Matcher matcher = storedProcedureMatcher.matcher(sqlText);
+    Matcher matcher = storedProcedurePattern.matcher(sqlText);
 
     if (!matcher.matches()) {
       throw new SQLException(format("Unable to detect stored procedure name from '%s'", sqlText));
     }
 
     return matcher.group(3);
+  }
+
+  /**
+   * Gets the Schema of the stored procedure of the given SQL Query.
+   *
+   * @param sqlText the SQL Query text
+   * @return an {@link Optional} with the Schema of the stored procedure
+   * @throws SQLException if the SQL Query syntax is not valid
+   */
+  public static Optional<String> getStoreProcedureSchema(String sqlText) throws SQLException {
+    Matcher matcher = storedProcedurePattern.matcher(sqlText);
+
+    if (!matcher.matches()) {
+      throw new SQLException(format("Unable to detect stored procedure schema from '%s'", sqlText));
+    }
+
+    String schemaText = matcher.group(2);
+
+    if (schemaText == null) {
+      return Optional.empty();
+    } else {
+      String schemaName = schemaText.substring(0, schemaText.length() - 1);
+      return Optional.of(schemaName);
+    }
   }
 
 }

--- a/src/test/java/org/mule/extension/db/internal/Utils/StoredProcedureUtilsTestCase.java
+++ b/src/test/java/org/mule/extension/db/internal/Utils/StoredProcedureUtilsTestCase.java
@@ -6,46 +6,45 @@
  */
 package org.mule.extension.db.internal.Utils;
 
-import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 
 import org.mule.extension.db.internal.util.StoredProcedureUtils;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 
-import java.util.Collection;
+import java.util.Optional;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-@RunWith(Parameterized.class)
 public class StoredProcedureUtilsTestCase extends AbstractMuleTestCase {
 
-  private String sqlQuery;
-
-  public StoredProcedureUtilsTestCase(String sqlQuery) {
-    this.sqlQuery = sqlQuery;
-  }
-
-  @Parameterized.Parameters
-  public static Collection<Object> data() {
-    return asList("call doSomething(?,?,?)",
-                  "call doSomething (?,?,?)",
-                  "call doSomething   (?,?,?)",
-                  "call doSomething(?,?,?)",
-                  "call   doSomething(?,?,?)",
-                  "call   doSomething   (?,?,?)",
-                  "call schema.doSomething (?,?,?)",
-                  "call schema.doSomething(?,?,?",
-                  "{ call doSomething(?,?,?) }",
-                  "{    call doSomething(?,?,?) }",
-                  "{call doSomething(?,?,?) }");
-
-  }
 
   @Test
   public void getStoredProcedureName() throws Exception {
-    assertEquals("doSomething", StoredProcedureUtils.getStoredProcedureName(sqlQuery));
+    assertEquals("doSomething", StoredProcedureUtils.getStoredProcedureName("call doSomething(?,?,?)"));
+    assertEquals("doSomething", StoredProcedureUtils.getStoredProcedureName("call doSomething (?,?,?)"));
+    assertEquals("doSomething", StoredProcedureUtils.getStoredProcedureName("call doSomething   (?,?,?)"));
+    assertEquals("doSomething", StoredProcedureUtils.getStoredProcedureName("call   doSomething(?,?,?)"));
+    assertEquals("doSomething", StoredProcedureUtils.getStoredProcedureName("call   doSomething   (?,?,?)"));
+    assertEquals("doSomething", StoredProcedureUtils.getStoredProcedureName("call schema.doSomething (?,?,?)"));
+    assertEquals("doSomething", StoredProcedureUtils.getStoredProcedureName("call schema.doSomething(?,?,?"));
+    assertEquals("doSomething", StoredProcedureUtils.getStoredProcedureName("{ call doSomething(?,?,?) }"));
+    assertEquals("doSomething", StoredProcedureUtils.getStoredProcedureName("{    call doSomething(?,?,?) }"));
+    assertEquals("doSomething", StoredProcedureUtils.getStoredProcedureName("{call doSomething(?,?,?) }"));
+  }
+
+  @Test
+  public void getStoredProcedureSchema() throws Exception {
+    assertEquals(Optional.empty(), StoredProcedureUtils.getStoreProcedureSchema("call doSomething(?,?,?)"));
+    assertEquals(Optional.empty(), StoredProcedureUtils.getStoreProcedureSchema("call doSomething (?,?,?)"));
+    assertEquals(Optional.empty(), StoredProcedureUtils.getStoreProcedureSchema("call doSomething   (?,?,?)"));
+    assertEquals(Optional.empty(), StoredProcedureUtils.getStoreProcedureSchema("call   doSomething(?,?,?)"));
+    assertEquals(Optional.empty(), StoredProcedureUtils.getStoreProcedureSchema("call   doSomething   (?,?,?)"));
+    assertEquals(Optional.empty(), StoredProcedureUtils.getStoreProcedureSchema("{ call doSomething(?,?,?) }"));
+    assertEquals(Optional.empty(), StoredProcedureUtils.getStoreProcedureSchema("{    call doSomething(?,?,?) }"));
+    assertEquals(Optional.empty(), StoredProcedureUtils.getStoreProcedureSchema("{call doSomething(?,?,?) }"));
+    assertEquals(Optional.of("schema"), StoredProcedureUtils.getStoreProcedureSchema("call schema.doSomething (?,?,?)"));
+    assertEquals(Optional.of("schema"), StoredProcedureUtils.getStoreProcedureSchema("call schema.doSomething(?,?,?"));
+    assertEquals(Optional.of("schema"), StoredProcedureUtils.getStoreProcedureSchema("{call schema.doSomething(?,?,?) }"));
   }
 
 }


### PR DESCRIPTION
… minutes

If merged, this commit add the capability of using the stored procedure
schema to narrow down the fetching of its parameters  metadata