### PR TITLE
Add space on info message using %d

### DIFF
--- a/src/main/java/org/mule/extension/db/internal/domain/executor/BulkUpdateExecutor.java
+++ b/src/main/java/org/mule/extension/db/internal/domain/executor/BulkUpdateExecutor.java
@@ -122,7 +122,7 @@ public class BulkUpdateExecutor extends AbstractExecutor implements BulkExecutor
           .error("BULK UPDATE EXCEPTION. DATABASE PROCESSED %d OPERATIONS SUCCESSFULLY AND STOPPED PROCESSING DUE TO EXCEPTION.",
                  successfulOperations + noInfoAvailable);
     } else {
-      LOGGER.info("SUCCESSFULLY EXECUTED BATCH OPERATION. TOTAL EXECUTED STATEMENTS: %d .", batchCount);
+      LOGGER.info("SUCCESSFULLY EXECUTED BATCH OPERATION. TOTAL EXECUTED STATEMENTS: {}.", batchCount);
     }
   }
 }

--- a/src/main/java/org/mule/extension/db/internal/domain/executor/BulkUpdateExecutor.java
+++ b/src/main/java/org/mule/extension/db/internal/domain/executor/BulkUpdateExecutor.java
@@ -122,7 +122,7 @@ public class BulkUpdateExecutor extends AbstractExecutor implements BulkExecutor
           .error("BULK UPDATE EXCEPTION. DATABASE PROCESSED %d OPERATIONS SUCCESSFULLY AND STOPPED PROCESSING DUE TO EXCEPTION.",
                  successfulOperations + noInfoAvailable);
     } else {
-      LOGGER.info("SUCCESSFULLY EXECUTED BATCH OPERATION. TOTAL EXECUTED STATEMENTS: %d.", batchCount);
+      LOGGER.info("SUCCESSFULLY EXECUTED BATCH OPERATION. TOTAL EXECUTED STATEMENTS: %d .", batchCount);
     }
   }
 }

--- a/src/main/java/org/mule/extension/db/internal/domain/executor/BulkUpdateExecutor.java
+++ b/src/main/java/org/mule/extension/db/internal/domain/executor/BulkUpdateExecutor.java
@@ -122,7 +122,7 @@ public class BulkUpdateExecutor extends AbstractExecutor implements BulkExecutor
           .error("BULK UPDATE EXCEPTION. DATABASE PROCESSED %d OPERATIONS SUCCESSFULLY AND STOPPED PROCESSING DUE TO EXCEPTION.",
                  successfulOperations + noInfoAvailable);
     } else {
-      LOGGER.info("SUCCESSFULLY EXECUTED BATCH OPERATION. TOTAL EXECUTED STATEMENTS: {}.", batchCount);
+      LOGGER.debug("SUCCESSFULLY EXECUTED BATCH OPERATION. TOTAL EXECUTED STATEMENTS: {}.", batchCount);
     }
   }
 }


### PR DESCRIPTION
At the end of successful execution, the logger component does not show the number of records processed;

`May 9th 2020, 15:51:42.507	SUCCESSFULLY EXECUTED BATCH OPERATION. TOTAL EXECUTED STATEMENTS: %d.`

