### PR TITLE
Throw a ModuleException instead of NoSuchElementException

### DIFF
--- a/src/main/java/org/mule/extension/db/internal/result/resultset/ResultSetIterator.java
+++ b/src/main/java/org/mule/extension/db/internal/result/resultset/ResultSetIterator.java
@@ -7,16 +7,17 @@
 
 package org.mule.extension.db.internal.result.resultset;
 
-import static org.slf4j.LoggerFactory.getLogger;
 import org.mule.extension.db.internal.result.row.RowHandler;
+import org.mule.runtime.extension.api.exception.ModuleException;
+import org.slf4j.Logger;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.NoSuchElementException;
 
-import org.slf4j.Logger;
+import static org.mule.extension.db.api.exception.connection.DbError.CONNECTIVITY;
+import static org.slf4j.LoggerFactory.getLogger;
 
 
 /**
@@ -67,7 +68,7 @@ public class ResultSetIterator implements Iterator<Map<String, Object>> {
       return rowHandler.process(resultSet);
     } catch (SQLException e) {
       LOGGER.warn("Unable to obtain next row", e);
-      throw new NoSuchElementException();
+      throw new ModuleException("Unable to obtain next row", CONNECTIVITY, e);
     }
   }
 

--- a/src/test/java/org/mule/extension/db/unit/ResultSetIteratorTestCase.java
+++ b/src/test/java/org/mule/extension/db/unit/ResultSetIteratorTestCase.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
 package org.mule.extension.db.unit;
 
 import org.junit.Test;
@@ -15,18 +21,18 @@ import static org.mockito.Mockito.when;
 
 public class ResultSetIteratorTestCase {
 
-    @Mock
-    private final ResultSet resultSetMock = mock(ResultSet.class);
+  @Mock
+  private final ResultSet resultSetMock = mock(ResultSet.class);
 
-    @Mock
-    private final RowHandler rowHandlerMock = mock(RowHandler.class);
+  @Mock
+  private final RowHandler rowHandlerMock = mock(RowHandler.class);
 
-    private final ResultSetIterator resultSetIterator = new ResultSetIterator(this.resultSetMock, this.rowHandlerMock);
+  private final ResultSetIterator resultSetIterator = new ResultSetIterator(this.resultSetMock, this.rowHandlerMock);
 
-    @Test(expected = ModuleException.class)
-    public void next_WhenProcessingNextRowThrowsSQLException_ThenModuleExceptionIsCreated() throws SQLException {
-        when(this.rowHandlerMock.process(any(ResultSet.class))).thenThrow(new SQLException("Some SQL Exception"));
+  @Test(expected = ModuleException.class)
+  public void next_WhenProcessingNextRowThrowsSQLException_ThenModuleExceptionIsCreated() throws SQLException {
+    when(this.rowHandlerMock.process(any(ResultSet.class))).thenThrow(new SQLException("Some SQL Exception"));
 
-        this.resultSetIterator.next();
-    }
+    this.resultSetIterator.next();
+  }
 }

--- a/src/test/java/org/mule/extension/db/unit/ResultSetIteratorTestCase.java
+++ b/src/test/java/org/mule/extension/db/unit/ResultSetIteratorTestCase.java
@@ -1,0 +1,32 @@
+package org.mule.extension.db.unit;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mule.extension.db.internal.result.resultset.ResultSetIterator;
+import org.mule.extension.db.internal.result.row.RowHandler;
+import org.mule.runtime.extension.api.exception.ModuleException;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ResultSetIteratorTestCase {
+
+    @Mock
+    private final ResultSet resultSetMock = mock(ResultSet.class);
+
+    @Mock
+    private final RowHandler rowHandlerMock = mock(RowHandler.class);
+
+    private final ResultSetIterator resultSetIterator = new ResultSetIterator(this.resultSetMock, this.rowHandlerMock);
+
+    @Test(expected = ModuleException.class)
+    public void next_WhenProcessingNextRowThrowsSQLException_ThenModuleExceptionIsCreated() throws SQLException {
+        when(this.rowHandlerMock.process(any(ResultSet.class))).thenThrow(new SQLException("Some SQL Exception"));
+
+        this.resultSetIterator.next();
+    }
+}


### PR DESCRIPTION
The NoSuchElementException is caught by AbstractObjectStreamBuffer(#114) and the user cannot catch it in a Try-Catch flow block. The ModuleException will bubble up and will allow exception handling in the flow.