### PR TITLE
No exception when array result is null

### DIFF
--- a/src/main/java/org/mule/extension/db/internal/domain/type/ArrayResolvedDbType.java
+++ b/src/main/java/org/mule/extension/db/internal/domain/type/ArrayResolvedDbType.java
@@ -57,7 +57,7 @@ public class ArrayResolvedDbType extends AbstractStructuredDbType {
 
   @Override
   public Object getParameterValue(CallableStatement statement, int index) throws SQLException {
-    Object array = statement.getArray(index).getArray();
+    Object array = statement.getArray(index) != null ? statement.getArray(index).getArray() : null;
     if (array instanceof Collection) {
       return ((Collection<?>) array).stream().map(this::processArray).collect(toList());
     } else if (array instanceof Object[]) {

--- a/src/test/java/org/mule/extension/db/internal/domain/type/ArrayResolvedDbTypeTestCase.java
+++ b/src/test/java/org/mule/extension/db/internal/domain/type/ArrayResolvedDbTypeTestCase.java
@@ -11,18 +11,22 @@ import static java.sql.Types.ARRAY;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static org.mule.extension.db.internal.domain.type.ArrayResolvedDbType.createUnsupportedTypeErrorMessage;
+
 import org.mule.extension.db.internal.domain.connection.DbConnection;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
 
 import java.sql.Array;
+import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -89,5 +93,14 @@ public class ArrayResolvedDbTypeTestCase extends AbstractMuleTestCase {
     expectedException.expectMessage(containsString(createUnsupportedTypeErrorMessage(value)));
 
     dataType.setParameterValue(statement, PARAM_INDEX, value, dbConnection);
+  }
+
+  @Test
+  public void getParameterValue_WhenGetArrayIsNull_ThenNoException() throws SQLException {
+    CallableStatement callableStatementMock = mock(CallableStatement.class);
+
+    Object parameterValue = dataType.getParameterValue(callableStatementMock, 1);
+
+    assertNull(parameterValue);
   }
 }


### PR DESCRIPTION
If a stored procedure returns a null array then do not throw any exception.