### PR TITLE
Updates mule-maven-plugin to 3.5.3 (#460)

### DIFF
--- a/src/test/resources/tita/stored-procedure-oracle-xmltype-app-pom.xml
+++ b/src/test/resources/tita/stored-procedure-oracle-xmltype-app-pom.xml
@@ -20,7 +20,7 @@
             <plugin>
                 <groupId>org.mule.tools.maven</groupId>
                 <artifactId>mule-maven-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.5.3</version>
                 <extensions>true</extensions>
                 <configuration>
                     <classifier>mule-application</classifier>


### PR DESCRIPTION
in order to avoid issues where mule-maven-plugin:3.5.1 uses mule-maven-client-impl:1.6.0-SNAPSHOT (which does not exist anymore).