### PR TITLE
DBCON-329: Allow using Oracle features in connections created as "generic"

### DIFF
--- a/src/main/java/org/mule/extension/db/internal/domain/connection/generic/DbGenericConnectionProvider.java
+++ b/src/main/java/org/mule/extension/db/internal/domain/connection/generic/DbGenericConnectionProvider.java
@@ -6,14 +6,23 @@
  */
 package org.mule.extension.db.internal.domain.connection.generic;
 
+import static org.mule.extension.db.internal.domain.connection.ConnectionUtils.isOracle;
 import static org.mule.runtime.api.meta.ExternalLibraryType.JAR;
 import static org.mule.db.commons.internal.domain.connection.DbConnectionProvider.DRIVER_FILE_NAME_PATTERN;
+
+import org.mule.db.commons.internal.domain.connection.DbConnection;
 import org.mule.db.commons.internal.domain.connection.generic.GenericConnectionProvider;
+import org.mule.db.commons.internal.domain.type.ResolvedDbType;
+import org.mule.extension.db.internal.domain.connection.oracle.OracleDbConnection;
 import org.mule.runtime.extension.api.annotation.Alias;
 import org.mule.runtime.extension.api.annotation.ExternalLib;
 
 import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
 import org.mule.runtime.api.connection.ConnectionProvider;
+
+import java.sql.Connection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * {@link ConnectionProvider} that creates connections for any kind of database using a JDBC URL
@@ -24,5 +33,16 @@ import org.mule.runtime.api.connection.ConnectionProvider;
 @ExternalLib(name = "JDBC Driver", description = "A JDBC driver which supports connecting to the Database",
     nameRegexpMatcher = DRIVER_FILE_NAME_PATTERN, type = JAR)
 public class DbGenericConnectionProvider extends GenericConnectionProvider {
+
+  private final Map<String, Map<Integer, ResolvedDbType>> resolvedDbTypesCache = new ConcurrentHashMap<>();
+
+  @Override
+  protected DbConnection createDbConnection(Connection connection) throws Exception {
+    if (isOracle(connection)) {
+      return new OracleDbConnection(connection, resolveCustomTypes(), resolvedDbTypesCache);
+    } else {
+      return super.createDbConnection(connection);
+    }
+  }
 
 }


### PR DESCRIPTION
Use OracleDbConnection when an Oracle database is detected while using a "generic" connection, thus enabling Oracle specific features.

This completes DBCON-329.