### PR TITLE
W-10673234: When a stored procedure is in a package Oracle returns duplicated parameter data if passed a null catalog.

### DIFF
--- a/src/main/java/org/mule/extension/db/internal/domain/connection/oracle/OracleDbConnection.java
+++ b/src/main/java/org/mule/extension/db/internal/domain/connection/oracle/OracleDbConnection.java
@@ -259,7 +259,8 @@ public class OracleDbConnection extends DefaultDbConnection {
       procedureColumns = dbMetaData.getProcedureColumns(storedProcedureOwner, connectionSchema, storedProcedureName, "%");
       if (!procedureColumns.isBeforeFirst()) {
         procedureColumns.close();
-        procedureColumns = dbMetaData.getProcedureColumns(catalogName == null ? "" : catalogName, storedProcedureOwner, storedProcedureName, "%");
+        procedureColumns = dbMetaData.getProcedureColumns(catalogName == null ? "" : catalogName, storedProcedureOwner,
+                                                          storedProcedureName, "%");
       }
     } else {
       procedureColumns = dbMetaData.getProcedureColumns(catalogName, connectionSchema, storedProcedureName, "%");

--- a/src/main/java/org/mule/extension/db/internal/domain/connection/oracle/OracleDbConnection.java
+++ b/src/main/java/org/mule/extension/db/internal/domain/connection/oracle/OracleDbConnection.java
@@ -259,7 +259,7 @@ public class OracleDbConnection extends DefaultDbConnection {
       procedureColumns = dbMetaData.getProcedureColumns(storedProcedureOwner, connectionSchema, storedProcedureName, "%");
       if (!procedureColumns.isBeforeFirst()) {
         procedureColumns.close();
-        procedureColumns = dbMetaData.getProcedureColumns("", storedProcedureOwner, storedProcedureName, "%");
+        procedureColumns = dbMetaData.getProcedureColumns(catalogName == null ? "" : catalogName, storedProcedureOwner, storedProcedureName, "%");
       }
     } else {
       procedureColumns = dbMetaData.getProcedureColumns(catalogName, connectionSchema, storedProcedureName, "%");

--- a/src/main/java/org/mule/extension/db/internal/domain/connection/oracle/OracleDbConnection.java
+++ b/src/main/java/org/mule/extension/db/internal/domain/connection/oracle/OracleDbConnection.java
@@ -258,7 +258,8 @@ public class OracleDbConnection extends DefaultDbConnection {
     } else if (!isBlank(storedProcedureOwner)) {
       procedureColumns = dbMetaData.getProcedureColumns(storedProcedureOwner, connectionSchema, storedProcedureName, "%");
       if (!procedureColumns.isBeforeFirst()) {
-        procedureColumns = dbMetaData.getProcedureColumns(catalogName, storedProcedureOwner, storedProcedureName, "%");
+        procedureColumns.close();
+        procedureColumns = dbMetaData.getProcedureColumns("", storedProcedureOwner, storedProcedureName, "%");
       }
     } else {
       procedureColumns = dbMetaData.getProcedureColumns(catalogName, connectionSchema, storedProcedureName, "%");


### PR DESCRIPTION
W-10673234: When a stored procedure is in a package Oracle returns duplicated parameter data if passed a null catalog.

Connection's getCatalog() in Oracle always returns null anyway so catalogName here is always null.

Other change: Close the previous metadata ResultSet if a new one will be requested.