### PR TITLE
W-11742823: Review registry objects needed only by “fat” tooling

### DIFF
--- a/src/test/java/org/mule/extension/db/integration/AbstractDbIntegrationTestCase.java
+++ b/src/test/java/org/mule/extension/db/integration/AbstractDbIntegrationTestCase.java
@@ -7,29 +7,28 @@
 
 package org.mule.extension.db.integration;
 
+import static org.mule.extension.db.integration.DbTestUtil.selectData;
+import static org.mule.extension.db.integration.TestRecordUtil.assertRecords;
+import static org.mule.metadata.api.model.MetadataFormat.JAVA;
+import static org.mule.runtime.core.api.connection.util.ConnectionProviderUtils.unwrapProviderWrapper;
+
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+
 import static org.apache.commons.lang3.StringUtils.endsWith;
-import static org.apache.commons.lang3.StringUtils.isAllBlank;
 import static org.apache.commons.lang3.StringUtils.replace;
 import static org.apache.commons.lang3.StringUtils.startsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.assertThat;
-import static org.mule.extension.db.integration.DbTestUtil.selectData;
-import static org.mule.extension.db.integration.TestRecordUtil.assertRecords;
-import static org.mule.metadata.api.model.MetadataFormat.JAVA;
-import static org.mule.runtime.api.component.location.Location.builder;
-import static org.mule.runtime.api.metadata.MetadataKeyBuilder.newKey;
-import static org.mule.runtime.core.api.connection.util.ConnectionProviderUtils.unwrapProviderWrapper;
 
+import org.mule.db.commons.internal.domain.connection.DbConnection;
 import org.mule.extension.db.api.StatementResult;
 import org.mule.extension.db.integration.model.AbstractTestDatabase;
 import org.mule.extension.db.integration.model.Field;
 import org.mule.extension.db.integration.model.Record;
-import org.mule.db.commons.internal.domain.connection.DbConnection;
 import org.mule.functional.api.flow.FlowRunner;
 import org.mule.functional.junit4.MuleArtifactFunctionalTestCase;
 import org.mule.metadata.api.ClassTypeLoader;
@@ -37,12 +36,10 @@ import org.mule.metadata.api.builder.BaseTypeBuilder;
 import org.mule.metadata.api.model.MetadataType;
 import org.mule.metadata.api.model.ObjectFieldType;
 import org.mule.metadata.api.model.ObjectType;
-import org.mule.runtime.api.component.location.Location;
 import org.mule.runtime.api.connection.ConnectionProvider;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.meta.model.operation.OperationModel;
-import org.mule.runtime.api.metadata.MetadataService;
 import org.mule.runtime.api.metadata.descriptor.ComponentMetadataDescriptor;
 import org.mule.runtime.api.metadata.resolving.MetadataResult;
 import org.mule.runtime.core.api.event.CoreEvent;
@@ -59,7 +56,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.inject.Inject;
 import javax.sql.DataSource;
 
 import org.junit.Before;
@@ -80,9 +76,6 @@ public abstract class AbstractDbIntegrationTestCase extends MuleArtifactFunction
 
   @Parameterized.Parameter(3)
   public List<String> vendorFlows;
-
-  @Inject
-  protected MetadataService metadataService;
 
   protected final BaseTypeBuilder typeBuilder = BaseTypeBuilder.create(JAVA);
   protected final ClassTypeLoader typeLoader = ExtensionsTypeLoaderFactory.getDefault().createTypeLoader();
@@ -268,22 +261,6 @@ public abstract class AbstractDbIntegrationTestCase extends MuleArtifactFunction
     return (Map<String, Object>) response.getPayload().getValue();
   }
 
-  protected MetadataResult<ComponentMetadataDescriptor<OperationModel>> getMetadata(String flow, String query) {
-    Location location = builder().globalName(flow).addProcessorsPart().addIndexPart(0).build();
-
-    return isAllBlank(query) ? metadataService.getOperationMetadata(location)
-        : metadataService.getOperationMetadata(location, newKey(query).build());
-  }
-
-  protected MetadataType getInputMetadata(String flow, String query) {
-    MetadataResult<ComponentMetadataDescriptor<OperationModel>> metadata = getMetadata(flow, query);
-
-    assertThat(metadata.isSuccess(), is(true));
-    return metadata.get().getModel().getAllParameterModels().stream()
-        .filter(p -> p.getName().equals("inputParameters") || p.getName().equals("bulkInputParameters"))
-        .findFirst().get().getType();
-  }
-
   protected void assertFieldRequirement(ObjectType record, String name, boolean required) {
     Optional<ObjectFieldType> field = record.getFieldByName(name);
     assertThat(field.isPresent(), is(true));
@@ -301,14 +278,6 @@ public abstract class AbstractDbIntegrationTestCase extends MuleArtifactFunction
     assertThat(metadata.get().getModel().getOutput().getType(), is(type));
   }
 
-  protected MetadataType getParameterValuesMetadata(String flow, String query) {
-    MetadataResult<ComponentMetadataDescriptor<OperationModel>> metadata = getMetadata(flow, query);
-    assertThat(metadata.isSuccess(), is(true));
-    return metadata.get().getModel().getAllParameterModels().stream()
-        .filter(p -> p.getName().equals("inputParameters") || p.getName().equals("bulkInputParameters"))
-        .findFirst().get().getType();
-  }
-
   public List<DbConfig> additionalConfigs() {
     return emptyList();
   }
@@ -324,8 +293,8 @@ public abstract class AbstractDbIntegrationTestCase extends MuleArtifactFunction
 
   public static class DbConfig {
 
-    private String name;
-    private Map<String, Object> variables;
+    private final String name;
+    private final Map<String, Object> variables;
 
     public DbConfig(String name, Map<String, Object> variables) {
       this.name = name;

--- a/src/test/java/org/mule/extension/db/integration/AbstractDbMetadataIntegrationTestCase.java
+++ b/src/test/java/org/mule/extension/db/integration/AbstractDbMetadataIntegrationTestCase.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.extension.db.integration;
+
+import static org.mule.runtime.api.component.location.Location.builder;
+import static org.mule.runtime.api.metadata.MetadataKeyBuilder.newKey;
+
+import static org.apache.commons.lang3.StringUtils.isAllBlank;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.mule.metadata.api.model.MetadataType;
+import org.mule.runtime.api.component.location.Location;
+import org.mule.runtime.api.meta.model.operation.OperationModel;
+import org.mule.runtime.api.metadata.MetadataService;
+import org.mule.runtime.api.metadata.descriptor.ComponentMetadataDescriptor;
+import org.mule.runtime.api.metadata.resolving.MetadataResult;
+import org.mule.test.runner.RunnerDelegateTo;
+
+import javax.inject.Inject;
+
+import org.junit.runners.Parameterized;
+
+@RunnerDelegateTo(Parameterized.class)
+public abstract class AbstractDbMetadataIntegrationTestCase extends AbstractDbIntegrationTestCase {
+
+  @Inject
+  protected MetadataService metadataService;
+
+  protected MetadataResult<ComponentMetadataDescriptor<OperationModel>> getMetadata(String flow, String query) {
+    Location location = builder().globalName(flow).addProcessorsPart().addIndexPart(0).build();
+
+    return isAllBlank(query) ? metadataService.getOperationMetadata(location)
+        : metadataService.getOperationMetadata(location, newKey(query).build());
+  }
+
+  protected MetadataType getInputMetadata(String flow, String query) {
+    MetadataResult<ComponentMetadataDescriptor<OperationModel>> metadata = getMetadata(flow, query);
+
+    assertThat(metadata.isSuccess(), is(true));
+    return metadata.get().getModel().getAllParameterModels().stream()
+        .filter(p -> p.getName().equals("inputParameters") || p.getName().equals("bulkInputParameters"))
+        .findFirst().get().getType();
+  }
+
+  protected MetadataType getParameterValuesMetadata(String flow, String query) {
+    MetadataResult<ComponentMetadataDescriptor<OperationModel>> metadata = getMetadata(flow, query);
+    assertThat(metadata.isSuccess(), is(true));
+    return metadata.get().getModel().getAllParameterModels().stream()
+        .filter(p -> p.getName().equals("inputParameters") || p.getName().equals("bulkInputParameters"))
+        .findFirst().get().getType();
+  }
+
+
+}

--- a/src/test/java/org/mule/extension/db/integration/delete/DeleteMetadataTestCase.java
+++ b/src/test/java/org/mule/extension/db/integration/delete/DeleteMetadataTestCase.java
@@ -10,8 +10,9 @@ package org.mule.extension.db.integration.delete;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import org.mule.extension.db.integration.AbstractDbIntegrationTestCase;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.mule.extension.db.integration.AbstractDbMetadataIntegrationTestCase;
 import org.mule.metadata.api.model.ArrayType;
 import org.mule.metadata.api.model.MetadataType;
 import org.mule.metadata.api.model.NullType;
@@ -22,7 +23,7 @@ import org.mule.runtime.api.metadata.resolving.MetadataResult;
 
 import org.junit.Test;
 
-public class DeleteMetadataTestCase extends AbstractDbIntegrationTestCase {
+public class DeleteMetadataTestCase extends AbstractDbMetadataIntegrationTestCase {
 
   @Override
   protected String[] getFlowConfigurationResources() {

--- a/src/test/java/org/mule/extension/db/integration/insert/InsertMetadataTestCase.java
+++ b/src/test/java/org/mule/extension/db/integration/insert/InsertMetadataTestCase.java
@@ -7,15 +7,15 @@
 
 package org.mule.extension.db.integration.insert;
 
+import static org.mule.extension.db.integration.DbTestUtil.DbType.ORACLE;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-
-import static org.junit.Assert.assertThat;
-import static org.mule.extension.db.integration.DbTestUtil.DbType.ORACLE;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.mule.extension.db.api.StatementResult;
-import org.mule.extension.db.integration.AbstractDbIntegrationTestCase;
+import org.mule.extension.db.integration.AbstractDbMetadataIntegrationTestCase;
 import org.mule.metadata.api.model.ArrayType;
 import org.mule.metadata.api.model.MetadataType;
 import org.mule.metadata.api.model.NullType;
@@ -24,10 +24,9 @@ import org.mule.runtime.api.meta.model.operation.OperationModel;
 import org.mule.runtime.api.metadata.descriptor.ComponentMetadataDescriptor;
 import org.mule.runtime.api.metadata.resolving.MetadataResult;
 
-import org.junit.Assume;
 import org.junit.Test;
 
-public class InsertMetadataTestCase extends AbstractDbIntegrationTestCase {
+public class InsertMetadataTestCase extends AbstractDbMetadataIntegrationTestCase {
 
   @Override
   protected String[] getFlowConfigurationResources() {

--- a/src/test/java/org/mule/extension/db/integration/select/SelectMetadataInputTestCase.java
+++ b/src/test/java/org/mule/extension/db/integration/select/SelectMetadataInputTestCase.java
@@ -13,15 +13,16 @@
 
 package org.mule.extension.db.integration.select;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assume.assumeThat;
 import static org.mule.extension.db.integration.DbTestUtil.DbType.MYSQL;
 
-import org.mule.extension.db.integration.AbstractDbIntegrationTestCase;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assume.assumeThat;
+
+import org.mule.extension.db.integration.AbstractDbMetadataIntegrationTestCase;
 import org.mule.metadata.api.model.NullType;
 import org.mule.metadata.api.model.ObjectFieldType;
 import org.mule.metadata.api.model.ObjectType;
@@ -33,7 +34,7 @@ import java.util.Optional;
 
 import org.junit.Test;
 
-public class SelectMetadataInputTestCase extends AbstractDbIntegrationTestCase {
+public class SelectMetadataInputTestCase extends AbstractDbMetadataIntegrationTestCase {
 
   @Override
   protected String[] getFlowConfigurationResources() {

--- a/src/test/java/org/mule/extension/db/integration/select/SelectMetadataOutputTestCase.java
+++ b/src/test/java/org/mule/extension/db/integration/select/SelectMetadataOutputTestCase.java
@@ -7,13 +7,14 @@
 
 package org.mule.extension.db.integration.select;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
 import static org.mule.db.commons.internal.domain.metadata.SelectMetadataResolver.DUPLICATE_COLUMN_LABEL_ERROR;
 
-import org.mule.extension.db.integration.AbstractDbIntegrationTestCase;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+import org.mule.extension.db.integration.AbstractDbMetadataIntegrationTestCase;
 import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.metadata.api.model.ArrayType;
 import org.mule.metadata.api.model.ObjectType;
@@ -26,7 +27,7 @@ import org.mule.runtime.extension.api.declaration.type.ExtensionsTypeLoaderFacto
 
 import org.junit.Test;
 
-public class SelectMetadataOutputTestCase extends AbstractDbIntegrationTestCase {
+public class SelectMetadataOutputTestCase extends AbstractDbMetadataIntegrationTestCase {
 
   private final ClassTypeLoader typeLoader = ExtensionsTypeLoaderFactory.getDefault().createTypeLoader();
 

--- a/src/test/java/org/mule/extension/db/integration/select/oracle/AbstractOracleUDTMetadataTestCase.java
+++ b/src/test/java/org/mule/extension/db/integration/select/oracle/AbstractOracleUDTMetadataTestCase.java
@@ -6,15 +6,14 @@
  */
 package org.mule.extension.db.integration.select.oracle;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static org.mule.tck.junit4.matcher.IsEmptyOptional.empty;
 
-import org.junit.After;
-import org.junit.Before;
-import org.mule.extension.db.integration.AbstractDbIntegrationTestCase;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.mule.extension.db.integration.AbstractDbMetadataIntegrationTestCase;
 import org.mule.extension.db.integration.model.OracleTestDatabase;
 import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.metadata.api.model.ArrayType;
@@ -29,10 +28,12 @@ import org.mule.runtime.extension.api.declaration.type.ExtensionsTypeLoaderFacto
 import java.sql.SQLException;
 import java.util.Optional;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
-public abstract class AbstractOracleUDTMetadataTestCase extends AbstractDbIntegrationTestCase {
+public abstract class AbstractOracleUDTMetadataTestCase extends AbstractDbMetadataIntegrationTestCase {
 
   @Parameterized.Parameter(4)
   public String flowSuffix;

--- a/src/test/java/org/mule/extension/db/integration/source/RowListenerTestCase.java
+++ b/src/test/java/org/mule/extension/db/integration/source/RowListenerTestCase.java
@@ -6,24 +6,22 @@
  */
 package org.mule.extension.db.integration.source;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
 import static org.mule.extension.db.integration.model.AbstractTestDatabase.ADDITIONAL_PLANET_VALUES;
 import static org.mule.extension.db.integration.model.AbstractTestDatabase.PLANET_TEST_VALUES;
 import static org.mule.runtime.api.component.location.Location.builder;
 import static org.mule.runtime.api.metadata.MetadataKeyBuilder.newKey;
 import static org.mule.tck.probe.PollingProber.check;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.mule.extension.db.integration.AbstractDbIntegrationTestCase;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+import org.mule.extension.db.integration.AbstractDbMetadataIntegrationTestCase;
 import org.mule.extension.db.integration.model.Planet;
 import org.mule.metadata.api.model.ObjectType;
 import org.mule.runtime.api.component.location.Location;
 import org.mule.runtime.api.lifecycle.Startable;
 import org.mule.runtime.api.meta.model.source.SourceModel;
-import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.api.metadata.descriptor.ComponentMetadataDescriptor;
 import org.mule.runtime.api.metadata.resolving.MetadataResult;
 import org.mule.runtime.core.api.event.CoreEvent;
@@ -33,9 +31,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
-public class RowListenerTestCase extends AbstractDbIntegrationTestCase {
+public class RowListenerTestCase extends AbstractDbMetadataIntegrationTestCase {
 
   private static final int TIMEOUT_MILLIS = 5000;
   public static List<Map<String, Object>> PAYLOADS;

--- a/src/test/java/org/mule/extension/db/integration/storedprocedure/StoredProcedureMetadataTestCase.java
+++ b/src/test/java/org/mule/extension/db/integration/storedprocedure/StoredProcedureMetadataTestCase.java
@@ -10,7 +10,8 @@ package org.mule.extension.db.integration.storedprocedure;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
-import org.mule.extension.db.integration.AbstractDbIntegrationTestCase;
+
+import org.mule.extension.db.integration.AbstractDbMetadataIntegrationTestCase;
 import org.mule.metadata.api.model.MetadataType;
 import org.mule.metadata.api.model.ObjectType;
 import org.mule.runtime.api.meta.model.operation.OperationModel;
@@ -20,7 +21,7 @@ import org.mule.runtime.api.metadata.resolving.MetadataResult;
 import org.junit.Before;
 import org.junit.Test;
 
-public class StoredProcedureMetadataTestCase extends AbstractDbIntegrationTestCase {
+public class StoredProcedureMetadataTestCase extends AbstractDbMetadataIntegrationTestCase {
 
   @Override
   protected String[] getFlowConfigurationResources() {

--- a/src/test/java/org/mule/extension/db/integration/update/UpdateMetadataTestCase.java
+++ b/src/test/java/org/mule/extension/db/integration/update/UpdateMetadataTestCase.java
@@ -8,12 +8,14 @@
 package org.mule.extension.db.integration.update;
 
 import static org.mule.extension.db.AllureConstants.DbFeature.DB_EXTENSION;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import org.mule.extension.db.api.StatementResult;
-import org.mule.extension.db.integration.AbstractDbIntegrationTestCase;
+import org.mule.extension.db.integration.AbstractDbMetadataIntegrationTestCase;
 import org.mule.metadata.api.model.ArrayType;
 import org.mule.metadata.api.model.MetadataType;
 import org.mule.metadata.api.model.NullType;
@@ -23,12 +25,13 @@ import org.mule.runtime.api.metadata.descriptor.ComponentMetadataDescriptor;
 import org.mule.runtime.api.metadata.resolving.MetadataResult;
 
 import org.junit.Test;
+
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
 @Feature(DB_EXTENSION)
 @Story("Update Statement")
-public class UpdateMetadataTestCase extends AbstractDbIntegrationTestCase {
+public class UpdateMetadataTestCase extends AbstractDbMetadataIntegrationTestCase {
 
   @Override
   protected String[] getFlowConfigurationResources() {


### PR DESCRIPTION
* Split tooling test from AbstractDbIntegrationTestCase