### PR TITLE
W-12545854: added process value output condition to BLOB values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <javax.transaction.version>1.3</javax.transaction.version>
         <xaPoolVersion>1.5.0</xaPoolVersion>
         <cglibVersion>3.3.0</cglibVersion>
-        <muleDbClientVersion>1.6.0</muleDbClientVersion>
+        <muleDbClientVersion>1.6.1</muleDbClientVersion>
         <muleExtensionsShadeVersion>1.0.4</muleExtensionsShadeVersion>
 
         <caffeineVersion>2.9.3</caffeineVersion>

--- a/src/test/munit/oracle/stored-procedure-blob-output-oracle-test-case.xml
+++ b/src/test/munit/oracle/stored-procedure-blob-output-oracle-test-case.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core"
+      xmlns:db="http://www.mulesoft.org/schema/mule/db"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+      xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+        http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+        http://www.mulesoft.org/schema/mule/db http://www.mulesoft.org/schema/mule/db/current/mule-db.xsd
+        http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+
+    <munit:config name="stored-procedure-blob-output-oracle-test-case.xml" minMuleVersion="4.1.6"/>
+    <munit:before-test name="createStoreProcedureBlob">
+        <db:execute-ddl config-ref="oracleDbPoolingConfig" >
+            <db:sql ><![CDATA[CREATE OR REPLACE PROCEDURE myProcBlobOut(myParam OUT BLOB) AS
+  aBlob NUMBER;
+BEGIN
+  SELECT to_number('1') into aBlob FROM dual;
+  myParam := utl_raw.cast_to_raw(aBlob);
+END;]]></db:sql>
+        </db:execute-ddl>
+    </munit:before-test>
+
+    <munit:test name="getBlobResultFromStoredProcedurePackage" ignore="#[java!org::mule::extension::db::DbMunitUtils::isTestIgnored('oracle')]">
+        <munit:execution>
+             <db:stored-procedure config-ref="dbConfigWithPooling">
+                 <db:sql><![CDATA[call myProcBlobOut(:blobdata)]]></db:sql>
+                 <db:output-parameters>
+                     <db:output-parameter key="blobdata" type="BLOB" />
+                 </db:output-parameters>
+             </db:stored-procedure>
+        </munit:execution>
+    </munit:test>
+
+    <munit:after-suite name="deleteStoreProcedureBlob">
+        <db:execute-script config-ref="oracleDbPoolingConfig">
+            <db:sql ><![CDATA[drop procedure myProcBlobOut]]></db:sql>
+        </db:execute-script>
+    </munit:after-suite>
+
+</mule>


### PR DESCRIPTION
_Hi, thank you for your work. We understand that you want to merge your changes and move on from this issue, but we also want to maintain the safety, readability, and testability of our code. Because of this, we kindly ask that you confirm that you have fulfilled the prerequisites for each category of activity before merging your changes._


### For ALL the Releases:

- [ ] There is a task in GUS for this change.
- [ ] The corresponding Release Notes have been written and shared with the documentation team.
- [ ] The new code has tests and they have before and after methods to be sure that you are working with a clean environment and that you are leaving the environment clean after they finish.
- [ ] If you are using reflection, create a test to call the methods you are invoking, this way, if there is a change in the API, the test will be able to detect it.
- [ ] If the project has a parent pom and modules, the release pipeline only uploads the modules, so, please, make sure that the parent was deployed in the repositories before considering this release finished.
- [ ] Notify in the Slack Channel that the release is complete, so the Docs team can merge the Documentation and Release Notes PR. The docs team always checks in Anypoint Exchange that the connector is released before merging the release notes.
- [ ] Add the connector build to GUS, and assign that build to the GUS ticket.
- [ ] Create a change case request, based on the Change Case Management doc https://docs.google.com/document/d/1tMJlTTZLaXMLiYwxlMBFY1yJwBmejhc4-IP8HAXgDfY/edit#

**NOTE**: _(applies only for Core-Connectors connectors and modules) The release process ends when you merge the pull request that updates the support branch to the new snapshot, please don't forget to do this._

### Patch Version:

- [ ] The Pull Request has been peer-reviewed.
- [ ] No backward compatibility is broken.
- [ ] Documentation: (Required) Release Notes PR with compatibility table. Share it with the Docs team.
